### PR TITLE
Parse API_swagger.yaml to populate EndpointTreeNode

### DIFF
--- a/srcs/services/api-gateway/app/main.rb
+++ b/srcs/services/api-gateway/app/main.rb
@@ -3,6 +3,5 @@ require_relative 'EndpointTreeNode.rb'
 # Define the RESTful API endpoints
 EndpointTree = EndpointTreeNode.new('v1') # Root node
 
-#TODO parse the API endpoints from a file and add them to the tree
-
-
+# Parse the API endpoints from the API_swagger.yaml file and add them to the tree
+EndpointTree.parse_swagger_file('config/API_swagger.yaml')


### PR DESCRIPTION
Add methods to parse `API_swagger.yaml` and populate `EndpointTreeNode`.

* **srcs/services/api-gateway/app/lib/EndpointTreeNode.rb**
  - Add `parse_swagger_file` method to parse the `API_swagger.yaml` file and populate the `EndpointTreeNode`.
  - Add `convert_security_to_auth_level` method to convert security definitions to auth levels.

* **srcs/services/api-gateway/app/main.rb**
  - Call the `parse_swagger_file` method to populate the `EndpointTree` with endpoints from `API_swagger.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Raimo33/ft_transcendence?shareId=4a5da11e-c601-42be-a87e-b08b62d3a575).