### PR TITLE
Make the API gateway server non-blocking

### DIFF
--- a/srcs/services/api-gateway/app/main.rb
+++ b/srcs/services/api-gateway/app/main.rb
@@ -6,51 +6,91 @@ require_relative 'grpc_client.rb'
 require_relative 'response_formatter.rb'
 require_relative 'helpers.rb'
 
+def handle_client_request(socket, endpoint_node, api_method, jwt_validator)
+  if api_method.auth_level != AuthLevel::NONE
+    auth_header = extract_headers(socket)['authorization']
+    unless check_auth_header(auth_header, jwt_validator, api_method.auth_level)
+      return_error(socket, 401, 'Invalid or missing JWT token')
+      return false
+    end
+  end
+
+  begin
+    response = # Placeholder for gRPC service call
+
+    socket.puts "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+    socket.puts response.to_json
+  rescue StandardError => e
+    return_error(socket, 500, e.message)
+  end
+
+  true
+end
+
+def handle_new_client(server, clients)
+  client = server.accept_nonblock
+  clients << client
+end
+
+def handle_existing_client(socket, clients, jwt_validator)
+  request_line = socket.gets
+  if request_line
+    method, path, _ = request_line.split
+    endpoint_node = EndpointTree.find_path(path)
+
+    unless endpoint_node && HttpMethod::VALID_HTTP_METHODS.include?(method.to_sym)
+      return_error(socket, 404, 'Invalid path or method')
+      clients.delete(socket)
+      return
+    end
+
+    api_method = endpoint_node.endpoint_data[method.to_sym]
+    unless api_method
+      return_error(socket, 405, 'Method not allowed')
+      clients.delete(socket)
+      return
+    end
+
+    if handle_client_request(socket, endpoint_node, api_method, jwt_validator)
+      clients.delete(socket)
+      socket.close
+    end
+  else
+    clients.delete(socket)
+    socket.close
+  end
+end
+
 begin
   EndpointTree = EndpointTreeNode.new('v1') # Root node
   EndpointTree.parse_swagger_file('app/config/API_swagger.yaml')
 
   jwt_validator = JwtValidator.new
 
-  #TODO non-blocking
   server = TCPServer.new('0.0.0.0', ENV['API_GATEWAY_PORT'])
+  clients = []
 
   loop do
-    client = server.accept
-    request_line = client.gets
-    next unless request_line
+    readable, writeable, error = IO.select([server] + clients)
 
-    method, path, _ = request_line.split
-    endpoint_node = EndpointTree.find_path(path)
+  #TODO handle writeable and error sockets (writeable solo per async?)
 
-    if !endpoint_node || !HttpMethod::VALID_HTTP_METHODS.include?(method.to_sym)
-      return_error(client, 404, 'Invalid path or method')
-      next
-    end
-
-    api_method = endpoint_node.endpoint_data[method.to_sym]
-    if !api_method
-      return_error(client, 405, 'Method not allowed')
-      next
-    end
-
-    if api_method.auth_level != AuthLevel::NONE
-      auth_header = extract_headers(client)['authorization']
-      if !check_auth_header(auth_header, jwt_validator, api_method.auth_level)
-        return_error(client, 401, 'Invalid or missing JWT token')
-        next
+    readable.each do |socket|
+      if socket == server
+        handle_new_client(server, clients)
+      else
+        handle_existing_client(socket, clients, jwt_validator)
       end
     end
 
-    begin
-      response = # Placeholder for gRPC service call
+    # Placeholder for future handling of writable sockets
+    writeable.each do |socket|
+      # Future implementation
+    end
 
-      client.puts "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
-      client.puts response.to_json
-    rescue StandardError => e
-      return_error(client, 500, e.message)
-    ensure
-      client.close
+    # Placeholder for future handling of error sockets
+    error.each do |socket|
+      # Future implementation
     end
   end
 rescue => e


### PR DESCRIPTION
Make the API gateway server non-blocking.

* Replace the blocking `TCPServer` with a non-blocking `IO.select` method to handle multiple client connections concurrently.
* Add a `clients` array to keep track of connected clients and their states.
* Process client requests in a non-blocking manner, allowing multiple clients to be handled simultaneously.
* Close client connections after processing their requests to free up resources.
* Add placeholders for future handling of writable and error sockets.
* Isolate logic in separate functions with good naming.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Raimo33/ft_transcendence?shareId=1822b2df-5046-467b-9ebf-b316b064535f).