### PR TITLE
Implement server.stop

### DIFF
--- a/srcs/services/api-gateway/app/lib/config_loader.rb
+++ b/srcs/services/api-gateway/app/lib/config_loader.rb
@@ -10,7 +10,19 @@
 #                                                                              #
 # **************************************************************************** #
 
+
 class ConfigLoader
+  VALID_KEYS = %i[
+    bind_address
+    bind_port
+    keycloak_host
+    keycloak_realm
+    keycloak_certs
+    jwt_cache_expiry
+    jwt_algorithm
+    thread_pool_size
+  ].freeze
+
   def initialize
     @config = {}
   end
@@ -36,9 +48,14 @@ class ConfigLoader
   private
 
   def validate_config_file(file_path)
-    #TODO check file name extension (expected: '.conf')
-    #TODO key and value are admitted (key exists in the ones expected, value is formatted correctly)
-    #throw exception
+    raise "Invalid file extension" unless File.extname(file_path) == '.conf'
+
+    File.readlines(file_path).each do |line|
+      key, value = line.strip.split('=', 2)
+      raise "Invalid key: #{key}" unless VALID_KEYS.include?(key.strip)
+      raise "Invalid value for key: #{key}" if value.strip.empty?
+    end
+  end
 
   def parse_config_file(file_path)
     config = {}

--- a/srcs/services/api-gateway/app/lib/endpoint_tree.rb
+++ b/srcs/services/api-gateway/app/lib/endpoint_tree.rb
@@ -16,16 +16,12 @@ module HttpMethod
   PUT = :PUT
   PATCH = :PATCH
   DELETE = :DELETE
-
-  VALID_HTTP_METHODS = [GET, POST, PUT, PATCH, DELETE].freeze
 end
 
 module AuthLevel
   NONE = :none
   USER = :user
   ADMIN = :admin
-
-  VALID_AUTH_LEVELS = [NONE, USER, ADMIN].freeze
 end
 
 class ApiMethod

--- a/srcs/services/api-gateway/app/lib/server.rb
+++ b/srcs/services/api-gateway/app/lib/server.rb
@@ -52,7 +52,12 @@ class Server
   end
 
   def stop
-    #TODO Implement graceful shutdown
+    @clients.each do |client|
+      client.close
+    end
+    @server.close
+    @thread_pool.shutdown
+  end
 
   private
 

--- a/srcs/services/api-gateway/app/main.rb
+++ b/srcs/services/api-gateway/app/main.rb
@@ -35,6 +35,18 @@ begin
     end
   end
 
+  Signal.trap('SIGTERM') do
+    begin
+      server.stop
+      exit 0
+    rescue StandardError => e
+      STDERR.puts "Error during shutdown: #{e.message}"
+      exit 1
+    end
+  end
+
+  server.run
+
 rescue => e
   STDERR.puts "Fatal Error: #{e.message}"
   exit 1


### PR DESCRIPTION
Implement server.stop method to handle graceful shutdown and add signal trapping for SIGTERM.

* **Server Class (`srcs/services/api-gateway/app/lib/server.rb`)**
  - Implement the `stop` method to close client connections, stop the server, and shut down the thread pool.

* **Main File (`srcs/services/api-gateway/app/main.rb`)**
  - Add signal trapping for `SIGTERM` to call the `stop` method on the server instance and handle shutdown errors.

* **ConfigLoader Class (`srcs/services/api-gateway/app/lib/config_loader.rb`)**
  - Add `VALID_KEYS` constant to define acceptable configuration keys.
  - Implement `validate_config_file` method to check file extension, validate keys, and ensure values are not empty.

* **EndpointTree Module (`srcs/services/api-gateway/app/lib/endpoint_tree.rb`)**
  - Remove `VALID_HTTP_METHODS` and `VALID_AUTH_LEVELS` constants.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Raimo33/ft_transcendence?shareId=f36d342d-a1a3-4533-a5dc-4e1e60cdd450).