### PR TITLE
Implement method to get gRPC service object based on service name

### DIFF
--- a/srcs/services/api-gateway/app/lib/endpoint_tree.rb
+++ b/srcs/services/api-gateway/app/lib/endpoint_tree.rb
@@ -98,8 +98,15 @@ class EndpointTreeNode
   end
 
   def _get_grpc_service_by_name(service_name)
-    # Implement this method to return the gRPC service object based on the service name
-    # This is a placeholder implementation
-    service_name
+    case service_name
+    when "UserService"
+      UserService::Stub.new
+    when "MatchService"
+      MatchService::Stub.new
+    when "TournamentService"
+      TournamentService::Stub.new
+    else
+      raise "Unknown gRPC service: #{service_name}"
+    end
   end
 end


### PR DESCRIPTION
Implement the `_get_grpc_service_by_name` method to return the actual gRPC service object based on the service name.

* Use a case statement to match the service name to the corresponding gRPC service object.
* Return `UserService::Stub.new` for "UserService".
* Return `MatchService::Stub.new` for "MatchService".
* Return `TournamentService::Stub.new` for "TournamentService".
* Raise an error if the service name does not match any known gRPC service.

Update `handle_existing_client` method in `server.rb` to use the gRPC service object.

* Replace placeholder implementation with actual gRPC service call.
* Add TODO comments for future improvements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Raimo33/ft_transcendence?shareId=b30153ae-21e8-4d98-a12d-a2d58a2d7fa1).